### PR TITLE
add getNetworkSystemMode() for SIM7600

### DIFF
--- a/src/TinyGsmClientSIM7600.h
+++ b/src/TinyGsmClientSIM7600.h
@@ -291,6 +291,17 @@ class TinyGsmSim7600 : public TinyGsmModem<TinyGsmSim7600>,
     return waitResponse() == 1;
   }
 
+  bool getNetworkSystemMode(bool& n, int16_t& stat) {
+    // n: whether to automatically report the system mode info
+    // stat: the current service. 0 if it not connected
+    sendAT(GF("+CNSMOD?"));
+    if (waitResponse(GF(GSM_NL "+CNSMOD:")) != 1) { return false; }
+    n    = streamGetIntBefore(',') != 0;
+    stat = streamGetIntBefore('\n');
+    waitResponse();
+    return true;
+  }
+
   String getLocalIPImpl() {
     sendAT(GF("+IPADDR"));  // Inquire Socket PDP address
     // sendAT(GF("+CGPADDR=1"));  // Show PDP address


### PR DESCRIPTION
The function implementation is more or less a copy from the SIM7000 function as the same command is supported by both modems